### PR TITLE
feat: allow multiple withdrawals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "bithive"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bitcoin",
  "getrandom 0.2.15",

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM rust:1.78.0-slim
 RUN apt-get update && apt-get install -y clang llvm
 RUN apt-get install -y build-essential
 
+RUN rustup target add wasm32-unknown-unknown
+RUN rustup component add clippy rustfmt rust-std
+
 WORKDIR /app
 
 COPY . .

--- a/bin/config/testnet4.ts
+++ b/bin/config/testnet4.ts
@@ -21,7 +21,7 @@ export const config: Config = {
     signer: "bithive.testnet",
     owner: "bithive.testnet",
     bip322Verifier: "bip322.testnet",
-    bithive: "testnet4.bithive.testnet",
+    bithive: "testnet4-2.bithive.testnet",
     chainSignatures: "v1.signer-prod.testnet",
     btcLightClient: "btclc.testnet",
   },

--- a/contracts/bithive/Cargo.toml
+++ b/contracts/bithive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bithive"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/contracts/bithive/src/account.rs
+++ b/contracts/bithive/src/account.rs
@@ -227,7 +227,12 @@ impl Account {
 
 impl From<AccountV1> for Account {
     fn from(value: AccountV1) -> Self {
-        let mut account = Self {
+        // TODO: ??
+        // if let Some(psbt) = value.pending_sign_psbt {
+        //     account.pending_sign_psbts.push(&psbt);
+        // }
+
+        Self {
             pubkey: value.pubkey.clone(),
             total_deposit: value.total_deposit,
             active_deposits: value.active_deposits,
@@ -237,13 +242,7 @@ impl From<AccountV1> for Account {
             nonce: value.nonce,
             pending_sign_psbts: Vector::new(StorageKey::PendingSignPsbts(value.pubkey)),
             pending_sign_deposit: value.pending_sign_deposit,
-        };
-
-        if let Some(psbt) = value.pending_sign_psbt {
-            account.pending_sign_psbts.push(&psbt);
         }
-
-        account
     }
 }
 

--- a/contracts/bithive/src/account.rs
+++ b/contracts/bithive/src/account.rs
@@ -217,15 +217,6 @@ impl Account {
 
         self.remove_active_deposit(&deposit_tx_id, deposit_vout);
         self.insert_withdrawn_deposit(deposit);
-
-        Event::Withdrawn {
-            user_pubkey: &self.pubkey.clone().into(),
-            withdrawal_tx_id: &tx_id.to_owned().into(),
-            deposit_tx_id: &deposit_tx_id.into(),
-            deposit_vout: deposit_vout.into(),
-            is_multisig,
-        }
-        .emit();
     }
 }
 

--- a/contracts/bithive/src/account.rs
+++ b/contracts/bithive/src/account.rs
@@ -61,6 +61,8 @@ pub struct Account {
     pub nonce: u64,
     /// list of withdrawal PSBTs that need to be signed via chain signatures
     pub pending_sign_psbts: Vector<PendingSignPsbt>,
+    /// size in bytes of the pending sign PSBTs
+    pub pending_sign_psbts_size: usize,
     /// deposit user paid to cover the storage of pending sign PSBT
     /// this should only be increased when needed
     pub pending_sign_deposit: Balance,
@@ -77,6 +79,7 @@ impl Account {
             queue_withdrawal_start_ts: 0,
             nonce: 0,
             pending_sign_psbts: Vector::new(StorageKey::PendingSignPsbts(pubkey)),
+            pending_sign_psbts_size: 0,
             pending_sign_deposit: 0,
         }
     }
@@ -185,6 +188,7 @@ impl Account {
         self.queue_withdrawal_start_ts = current_timestamp_ms();
         self.nonce += 1;
         self.pending_sign_psbts.clear();
+        self.pending_sign_psbts_size = 0;
 
         Event::QueueWithdrawal {
             user_pubkey: &self.pubkey.clone().into(),
@@ -227,11 +231,6 @@ impl Account {
 
 impl From<AccountV1> for Account {
     fn from(value: AccountV1) -> Self {
-        // TODO: ??
-        // if let Some(psbt) = value.pending_sign_psbt {
-        //     account.pending_sign_psbts.push(&psbt);
-        // }
-
         Self {
             pubkey: value.pubkey.clone(),
             total_deposit: value.total_deposit,
@@ -241,6 +240,7 @@ impl From<AccountV1> for Account {
             queue_withdrawal_start_ts: value.queue_withdrawal_start_ts,
             nonce: value.nonce,
             pending_sign_psbts: Vector::new(StorageKey::PendingSignPsbts(value.pubkey)),
+            pending_sign_psbts_size: 0,
             pending_sign_deposit: value.pending_sign_deposit,
         }
     }

--- a/contracts/bithive/src/account.rs
+++ b/contracts/bithive/src/account.rs
@@ -42,6 +42,8 @@ pub struct AccountV1 {
     pub pending_sign_deposit: Balance,
 }
 
+/// second version of the account, which allows multiple pending sign PSBTs
+/// this is the current version of account
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct Account {
     pub pubkey: PubKey,
@@ -245,6 +247,7 @@ impl From<AccountV1> for Account {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(BorshDeserialize, BorshSerialize)]
 pub enum VersionedAccount {
     V1(AccountV1),

--- a/contracts/bithive/src/account.rs
+++ b/contracts/bithive/src/account.rs
@@ -2,7 +2,7 @@ use std::cmp::min;
 
 use near_sdk::{
     borsh::{self, BorshDeserialize, BorshSerialize},
-    collections::UnorderedMap,
+    collections::{UnorderedMap, Vector},
     require, Balance, Timestamp,
 };
 use serde::Serialize;
@@ -19,8 +19,9 @@ const ERR_DEPOSIT_ALREADY_WITHDRAWN: &str = "Deposit already withdrawn";
 
 const ERR_INVALID_QUEUE_WITHDRAWAL: &str = "Invalid queue withdrawal amount";
 
+/// first version of the account, which allows only one pending sign PSBT
 #[derive(BorshDeserialize, BorshSerialize)]
-pub struct Account {
+pub struct AccountV1 {
     pub pubkey: PubKey,
     /// total deposit amount in full BTC decimals
     pub total_deposit: u64,
@@ -41,17 +42,39 @@ pub struct Account {
     pub pending_sign_deposit: Balance,
 }
 
+#[derive(BorshDeserialize, BorshSerialize)]
+pub struct Account {
+    pub pubkey: PubKey,
+    /// total deposit amount in full BTC decimals
+    pub total_deposit: u64,
+    /// set of deposits that are not known to be withdrawn
+    active_deposits: UnorderedMap<OutputId, VersionedDeposit>,
+    /// set of deposits that are confirmed to have been withdrawn
+    withdrawn_deposits: UnorderedMap<OutputId, VersionedDeposit>,
+    /// amount of deposits queued for withdrawal in full BTC decimals
+    pub queue_withdrawal_amount: u64,
+    /// timestamp when the queue withdrawal started in ms
+    pub queue_withdrawal_start_ts: Timestamp,
+    /// nonce is used in signing messages to prevent replay attacks
+    pub nonce: u64,
+    /// list of withdrawal PSBTs that need to be signed via chain signatures
+    pub pending_sign_psbts: Vector<PendingSignPsbt>,
+    /// deposit user paid to cover the storage of pending sign PSBT
+    /// this should only be increased when needed
+    pub pending_sign_deposit: Balance,
+}
+
 impl Account {
     pub fn new(pubkey: PubKey) -> Account {
         Account {
             pubkey: pubkey.clone(),
             total_deposit: 0,
             active_deposits: UnorderedMap::new(StorageKey::ActiveDeposits(pubkey.clone())),
-            withdrawn_deposits: UnorderedMap::new(StorageKey::WithdrawnDeposits(pubkey)),
+            withdrawn_deposits: UnorderedMap::new(StorageKey::WithdrawnDeposits(pubkey.clone())),
             queue_withdrawal_amount: 0,
             queue_withdrawal_start_ts: 0,
             nonce: 0,
-            pending_sign_psbt: None,
+            pending_sign_psbts: Vector::new(StorageKey::PendingSignPsbts(pubkey)),
             pending_sign_deposit: 0,
         }
     }
@@ -159,7 +182,7 @@ impl Account {
         self.queue_withdrawal_amount += amount;
         self.queue_withdrawal_start_ts = current_timestamp_ms();
         self.nonce += 1;
-        self.pending_sign_psbt = None;
+        self.pending_sign_psbts.clear();
 
         Event::QueueWithdrawal {
             user_pubkey: &self.pubkey.clone().into(),
@@ -200,8 +223,31 @@ impl Account {
     }
 }
 
+impl From<AccountV1> for Account {
+    fn from(value: AccountV1) -> Self {
+        let mut account = Self {
+            pubkey: value.pubkey.clone(),
+            total_deposit: value.total_deposit,
+            active_deposits: value.active_deposits,
+            withdrawn_deposits: value.withdrawn_deposits,
+            queue_withdrawal_amount: value.queue_withdrawal_amount,
+            queue_withdrawal_start_ts: value.queue_withdrawal_start_ts,
+            nonce: value.nonce,
+            pending_sign_psbts: Vector::new(StorageKey::PendingSignPsbts(value.pubkey)),
+            pending_sign_deposit: value.pending_sign_deposit,
+        };
+
+        if let Some(psbt) = value.pending_sign_psbt {
+            account.pending_sign_psbts.push(&psbt);
+        }
+
+        account
+    }
+}
+
 #[derive(BorshDeserialize, BorshSerialize)]
 pub enum VersionedAccount {
+    V1(AccountV1),
     Current(Account),
 }
 
@@ -209,6 +255,7 @@ impl From<VersionedAccount> for Account {
     fn from(value: VersionedAccount) -> Self {
         match value {
             VersionedAccount::Current(a) => a,
+            VersionedAccount::V1(a) => a.into(),
         }
     }
 }

--- a/contracts/bithive/src/events.rs
+++ b/contracts/bithive/src/events.rs
@@ -33,9 +33,6 @@ pub enum Event<'a> {
     Withdrawn {
         user_pubkey: &'a String,
         withdrawal_tx_id: &'a String,
-        deposit_tx_id: &'a String,
-        deposit_vout: U64,
-        is_multisig: bool,
     },
     OwnerChanged {
         old_owner: &'a String,

--- a/contracts/bithive/src/ext/btc_light_client.rs
+++ b/contracts/bithive/src/ext/btc_light_client.rs
@@ -9,7 +9,7 @@ use serde::{
     Deserialize, Serialize,
 };
 
-pub const GAS_LIGHT_CLIENT_VERIFY: Gas = Gas(30 * Gas::ONE_TERA.0);
+pub const GAS_LIGHT_CLIENT_VERIFY: Gas = Gas(5 * Gas::ONE_TERA.0);
 
 #[ext_contract(ext_btc_light_client)]
 #[allow(dead_code)]

--- a/contracts/bithive/src/ext/chain_signatures.rs
+++ b/contracts/bithive/src/ext/chain_signatures.rs
@@ -35,5 +35,5 @@ pub trait ChainSignatures {
     fn sign(&mut self, request: SignRequest) -> Promise;
 
     /// returns the root public key
-    fn public_key(&self) -> near_sdk::PublicKey;
+    fn public_key(&self, domain_id: Option<u64>) -> near_sdk::PublicKey;
 }

--- a/contracts/bithive/src/lib.rs
+++ b/contracts/bithive/src/lib.rs
@@ -92,7 +92,7 @@ impl Contract {
         );
         ext_chain_signatures::ext(self.chain_signatures_id.clone())
             .with_static_gas(GAS_GET_ROOT_PUBKEY)
-            .public_key()
+            .public_key(None)
             .then(
                 Self::ext(env::current_account_id())
                     .with_static_gas(GAS_GET_ROOT_PUBKEY_CB)

--- a/contracts/bithive/src/types.rs
+++ b/contracts/bithive/src/types.rs
@@ -11,6 +11,7 @@ pub enum StorageKey {
     Accounts,
     ActiveDeposits(PubKey),
     WithdrawnDeposits(PubKey),
+    PendingSignPsbts(PubKey),
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]

--- a/contracts/bithive/src/upgrade.rs
+++ b/contracts/bithive/src/upgrade.rs
@@ -30,3 +30,13 @@ impl Contract {
             .into()
     }
 }
+
+#[near_bindgen]
+impl Contract {
+    /// This helps to migrate v1 accounts which has pending_sign_psbt to the latest version.
+    /// Needs to be called by a v1 account before doing view calls
+    pub fn migrate_account_v1(&mut self, user_pubkey: String) {
+        let account = self.get_account(&user_pubkey.into());
+        self.set_account(account.into());
+    }
+}

--- a/contracts/bithive/src/upgrade.rs
+++ b/contracts/bithive/src/upgrade.rs
@@ -37,6 +37,6 @@ impl Contract {
     /// Needs to be called by a v1 account before doing view calls
     pub fn migrate_account_v1(&mut self, user_pubkey: String) {
         let account = self.get_account(&user_pubkey.into());
-        self.set_account(account.into());
+        self.set_account(account);
     }
 }

--- a/contracts/bithive/src/upgrade.rs
+++ b/contracts/bithive/src/upgrade.rs
@@ -1,4 +1,4 @@
-use crate::{view::ContractSummary, Contract, ContractExt};
+use crate::{account::VersionedAccount, view::ContractSummary, Contract, ContractExt};
 use near_sdk::{
     assert_one_yocto, env, near_bindgen, Gas, GasWeight, Promise, PromiseOrValue, ONE_YOCTO,
 };
@@ -33,10 +33,25 @@ impl Contract {
 
 #[near_bindgen]
 impl Contract {
-    /// This helps to migrate v1 accounts which has pending_sign_psbt to the latest version.
-    /// Needs to be called by a v1 account before doing view calls
-    pub fn migrate_account_v1(&mut self, user_pubkey: String) {
-        let account = self.get_account(&user_pubkey.into());
-        self.set_account(account);
+    /// Whether the account needs to be migrated before doing view calls.
+    /// To migrate, call `migrate_account` function.
+    pub fn need_migrate_account(&self, user_pubkey: String) -> bool {
+        if let Some(account) = self.accounts.get(&user_pubkey.into()) {
+            return match account {
+                VersionedAccount::V1(v1) => v1.pending_sign_psbt.is_some(),
+                VersionedAccount::Current(_) => false,
+            };
+        }
+
+        false
+    }
+
+    /// This helps to migrate old accounts to the latest version.
+    /// If the function returns false, it means there is no need to migrate.
+    pub fn migrate_account(&mut self, user_pubkey: String) {
+        if self.need_migrate_account(user_pubkey.clone()) {
+            let account = self.get_account(&user_pubkey.into());
+            self.set_account(account);
+        }
     }
 }

--- a/contracts/bithive/src/view.rs
+++ b/contracts/bithive/src/view.rs
@@ -1,12 +1,12 @@
 use std::cmp::min;
 
-use crate::{types::PendingSignPsbt, *};
+use crate::*;
 use account::{Deposit, DepositStatus};
 use bitcoin::{consensus::encode::deserialize_hex, Psbt, Transaction};
 use consts::CHAIN_SIGNATURES_PATH_V1;
 use near_sdk::{json_types::U128, Timestamp};
 use serde::{Deserialize, Serialize};
-use types::{output_id, DepositEmbedMsg};
+use types::{output_id, DepositEmbedMsg, PendingSignPsbt};
 use withdraw::{verify_pending_sign_partial_sig, verify_sign_withdrawal_psbt, withdrawal_message};
 
 #[derive(Serialize, Deserialize)]

--- a/contracts/bithive/src/view.rs
+++ b/contracts/bithive/src/view.rs
@@ -268,7 +268,7 @@ impl Contract {
             let pending_sign_psbt = account
                 .pending_sign_psbts
                 .get(pending_sign_psbt_idx)
-                .unwrap();
+                .expect("pending sign PSBT not found");
             verify_sign_withdrawal_psbt(&pending_sign_psbt, &psbt);
         } else {
             verify_pending_sign_partial_sig(&psbt, vin_to_sign, &user_pubkey);

--- a/contracts/bithive/src/view.rs
+++ b/contracts/bithive/src/view.rs
@@ -1,12 +1,12 @@
 use std::cmp::min;
 
-use crate::*;
+use crate::{types::PendingSignPsbt, *};
 use account::{Deposit, DepositStatus};
 use bitcoin::{consensus::encode::deserialize_hex, Psbt, Transaction};
 use consts::CHAIN_SIGNATURES_PATH_V1;
 use near_sdk::{json_types::U128, Timestamp};
 use serde::{Deserialize, Serialize};
-use types::{output_id, DepositEmbedMsg, PendingSignPsbt};
+use types::{output_id, DepositEmbedMsg};
 use withdraw::{verify_pending_sign_partial_sig, verify_sign_withdrawal_psbt, withdrawal_message};
 
 #[derive(Serialize, Deserialize)]
@@ -63,7 +63,7 @@ pub struct AccountView {
     /// nonce is used in signing messages to prevent replay attacks
     pub nonce: u64,
     /// PSBT of the withdrawal txn that needs to be signed via chain signatures
-    pub pending_sign_psbt: Option<PendingSignPsbt>,
+    pub pending_sign_psbts_len: u64,
     /// deposit user paid to cover the storage of pending sign PSBT
     /// this should only be increased when needed
     pub pending_sign_deposit: U128,
@@ -207,6 +207,21 @@ impl Contract {
             .or_else(|| account.try_get_withdrawn_deposit(&tx_id.into(), vout))
     }
 
+    pub fn list_pending_sign_psbts(
+        &self,
+        user_pubkey: String,
+        offset: u64,
+        limit: u64,
+    ) -> Vec<PendingSignPsbt> {
+        let account = self.get_account(&user_pubkey.into());
+        account
+            .pending_sign_psbts
+            .iter()
+            .skip(offset as usize)
+            .take(limit as usize)
+            .collect()
+    }
+
     /// Dry run deposit txn to verify if it can be accepted or not
     /// ### Arguments
     /// * `tx_hex` - hex encoded transaction
@@ -234,6 +249,7 @@ impl Contract {
         psbt_hex: String,
         user_pubkey: String,
         vin_to_sign: u64,
+        pending_sign_psbt_idx: Option<u64>,
         reinvest_embed_vout: Option<u64>,
     ) {
         self.assert_running();
@@ -248,8 +264,12 @@ impl Contract {
             input_to_sign.previous_output.vout.into(),
         );
 
-        if account.pending_sign_psbt.is_some() {
-            verify_sign_withdrawal_psbt(account.pending_sign_psbt.as_ref().unwrap(), &psbt);
+        if let Some(pending_sign_psbt_idx) = pending_sign_psbt_idx {
+            let pending_sign_psbt = account
+                .pending_sign_psbts
+                .get(pending_sign_psbt_idx)
+                .unwrap();
+            verify_sign_withdrawal_psbt(&pending_sign_psbt, &psbt);
         } else {
             verify_pending_sign_partial_sig(&psbt, vin_to_sign, &user_pubkey);
             self.verify_pending_sign_request_amount(&account, &psbt, reinvest_embed_vout);
@@ -270,7 +290,7 @@ impl Contract {
                 account.queue_withdrawal_start_ts + self.withdrawal_waiting_time_ms
             },
             nonce: account.nonce,
-            pending_sign_psbt: account.pending_sign_psbt.clone(),
+            pending_sign_psbts_len: account.pending_sign_psbts.len(),
             pending_sign_deposit: account.pending_sign_deposit.into(),
         }
     }

--- a/contracts/bithive/src/view.rs
+++ b/contracts/bithive/src/view.rs
@@ -67,6 +67,8 @@ pub struct AccountView {
     /// deposit user paid to cover the storage of pending sign PSBT
     /// this should only be increased when needed
     pub pending_sign_deposit: U128,
+    /// size in bytes of the pending sign PSBTs
+    pub pending_sign_psbts_size: usize,
 }
 
 /// Constants for withdrawing v1 deposits
@@ -315,6 +317,7 @@ impl Contract {
             nonce: account.nonce,
             pending_sign_psbts_len: account.pending_sign_psbts.len(),
             pending_sign_deposit: account.pending_sign_deposit.into(),
+            pending_sign_psbts_size: account.pending_sign_psbts_size,
         }
     }
 }

--- a/contracts/bithive/src/view.rs
+++ b/contracts/bithive/src/view.rs
@@ -255,9 +255,9 @@ impl Contract {
         self.assert_running();
         let psbt_bytes = hex::decode(psbt_hex).unwrap();
         let psbt = Psbt::deserialize(&psbt_bytes).unwrap();
+        verify_pending_sign_partial_sig(&psbt, vin_to_sign, &user_pubkey);
 
         let account = self.get_account(&user_pubkey.clone().into());
-
         let input_to_sign = psbt.unsigned_tx.input.get(vin_to_sign as usize).unwrap();
         account.get_active_deposit(
             &input_to_sign.previous_output.txid.to_string().into(),
@@ -271,7 +271,6 @@ impl Contract {
                 .expect("pending sign PSBT not found");
             verify_sign_withdrawal_psbt(&pending_sign_psbt, &psbt);
         } else {
-            verify_pending_sign_partial_sig(&psbt, vin_to_sign, &user_pubkey);
             self.verify_pending_sign_request_amount(&account, &psbt, reinvest_embed_vout);
         }
     }

--- a/contracts/bithive/src/withdraw.rs
+++ b/contracts/bithive/src/withdraw.rs
@@ -31,6 +31,8 @@ const GAS_BIP322_VERIFY_CB: Gas = Gas(20 * Gas::ONE_TERA.0);
 const ERR_BIP322_NOT_ENABLED: &str = "BIP322 is not enabled";
 const ERR_INVALID_WITHDRAWAL_AMOUNT: &str = "Withdrawal amount must be greater than 0";
 // sign withdrawal errors
+const ERR_INVALID_PENDING_SIGN_PSBT_IDX: &str = "Invalid pending sign PSBT index";
+const ERR_TOO_MANY_PENDING_SIGN_PSBT: &str = "Too many pending sign PSBTs";
 const ERR_INVALID_STORAGE_DEPOSIT: &str = "Invalid storage deposit amount";
 const ERR_INSUFFICIENT_STORAGE_DEPOSIT: &str = "Insufficient storage deposit";
 const ERR_INVALID_PSBT_HEX: &str = "Invalid PSBT hex";
@@ -47,6 +49,7 @@ const ERR_PSBT_REINVEST_OUTPUT_MISMATCH: &str = "PSBT reinvest output mismatch";
 const ERR_INVALID_TX_HEX: &str = "Invalid txn hex";
 const ERR_NOT_WITHDRAW_TXN: &str = "Not a withdrawal transaction";
 
+const MAX_PENDING_SIGN_PSBT_LEN: u64 = 100;
 const REFUND_THRESHOLD: Balance = ONE_NEAR / 100; // 0.01 NEAR
 
 /// in case different wallet signs message in different form,
@@ -146,6 +149,7 @@ impl Contract {
     /// * `psbt_hex` - hex encoded PSBT to sign, must be partially signed by the user first
     /// * `user_pubkey` - user public key
     /// * `vin_to_sign` - vin to sign, must be an active deposit UTXO
+    /// * `pending_sign_psbt_idx` - index of the pending sign PSBT saved previously
     /// * `reinvest_embed_vout` - vout of the reinvestment deposit embed UTXO
     /// * `storage_deposit` - attached NEAR amount as storage deposit for pending sign PSBT
     #[payable]
@@ -154,6 +158,7 @@ impl Contract {
         psbt_hex: String,
         user_pubkey: String,
         vin_to_sign: u64,
+        pending_sign_psbt_idx: Option<u64>,
         reinvest_embed_vout: Option<u64>,
         storage_deposit: Option<U128>,
     ) -> Promise {
@@ -174,23 +179,32 @@ impl Contract {
             input_to_sign.previous_output.vout.into(),
         );
 
-        if account.pending_sign_psbt.is_some() {
-            // if the user has previously requested to sign a withdrawal tx, he cannot request to
-            // sign another one until the previous one is completed or replaced by fee
-            verify_sign_withdrawal_psbt(account.pending_sign_psbt.as_ref().unwrap(), &psbt);
+        if let Some(pending_sign_psbt_idx) = pending_sign_psbt_idx {
+            // if a pending sign PSBT index is provided, the PSBT must be the same or RBF of the saved PSBT
+            let saved_psbt = account
+                .pending_sign_psbts
+                .get(pending_sign_psbt_idx)
+                .expect(ERR_INVALID_PENDING_SIGN_PSBT_IDX);
+            verify_sign_withdrawal_psbt(&saved_psbt, &psbt);
         } else {
-            // if not, verify the withdrawal PSBT and save it for signing
+            // if no pending sign PSBT index is provided, treat the PSBT as a new request, which should decrease the queue withdrawal amount
+            require!(
+                account.pending_sign_psbts.len() <= MAX_PENDING_SIGN_PSBT_LEN,
+                ERR_TOO_MANY_PENDING_SIGN_PSBT
+            );
+
             verify_pending_sign_partial_sig(&psbt, vin_to_sign, &user_pubkey);
-            let reinvest_deposit_vout =
+            let (actual_withdraw_amount, reinvest_deposit_vout) =
                 self.verify_pending_sign_request_amount(&account, &psbt, reinvest_embed_vout);
 
-            // if there is more than one input in PSBT, we charge the user for PSBT storage deposit
-            if psbt.unsigned_tx.input.len() > 1 {
+            // if there are more than one pending sign PSBT or the PSBT has more than one input, we need to charge the user for PSBT storage deposit
+            if !account.pending_sign_psbts.is_empty() || psbt.unsigned_tx.input.len() > 1 {
                 attached_near_for_storage = storage_deposit.unwrap_or(U128::from(0)).into();
                 require!(
                     env::attached_deposit() >= attached_near_for_storage,
                     ERR_INVALID_STORAGE_DEPOSIT
                 );
+                // charge at least for the PSBT itself, but the user can attach more for future use
                 let storage_needed = psbt_bytes.len() as u128 * env::storage_byte_cost();
                 require!(
                     account.pending_sign_deposit + attached_near_for_storage >= storage_needed,
@@ -198,16 +212,12 @@ impl Contract {
                 );
             }
 
-            // update account state
-            account.pending_sign_psbt = Some(PendingSignPsbt {
+            account.pending_sign_psbts.push(&PendingSignPsbt {
                 psbt: psbt.clone().into(),
                 reinvest_deposit_vout,
                 reinvest_embed_vout,
             });
-            account.pending_sign_deposit += attached_near_for_storage;
-            // reset queue withdrawal amount
-            account.queue_withdrawal_amount = 0;
-            account.queue_withdrawal_start_ts = 0;
+            account.queue_withdrawal_amount -= actual_withdraw_amount;
 
             self.set_account(account);
         }
@@ -333,13 +343,13 @@ impl Contract {
 
 impl Contract {
     /// Verify if the withdrawal amount in the PSBT is valid
-    /// Returns the reinvest deposit vout if any
+    /// Returns the actual withdrawal amount and the reinvest deposit vout if any
     pub(crate) fn verify_pending_sign_request_amount(
         &self,
         account: &Account,
         psbt: &Psbt,
         reinvest_embed_vout: Option<u64>,
-    ) -> Option<u64> {
+    ) -> (u64, Option<u64>) {
         require!(
             account.queue_withdrawal_amount > 0 && account.queue_withdrawal_start_ts > 0,
             ERR_NO_WITHDRAW_REQUESTED
@@ -384,12 +394,14 @@ impl Contract {
         );
 
         // return the reinvest deposit vout if any
-        reinvest_embed_vout.map(|embed_vout| {
+        let reinvest_deposit_vout = reinvest_embed_vout.map(|embed_vout| {
             let embed_msg = self.verify_embed_output(&psbt.unsigned_tx, embed_vout);
             match embed_msg {
                 DepositEmbedMsg::V1 { deposit_vout, .. } => deposit_vout,
             }
-        })
+        });
+
+        (actual_withdraw_amount, reinvest_deposit_vout)
     }
 }
 

--- a/contracts/bithive/src/withdraw.rs
+++ b/contracts/bithive/src/withdraw.rs
@@ -33,6 +33,7 @@ const ERR_INVALID_WITHDRAWAL_AMOUNT: &str = "Withdrawal amount must be greater t
 // sign withdrawal errors
 const ERR_INVALID_PENDING_SIGN_PSBT_IDX: &str = "Invalid pending sign PSBT index";
 const ERR_TOO_MANY_PENDING_SIGN_PSBT: &str = "Too many pending sign PSBTs";
+const ERR_TOO_MANY_PENDING_SIGN_PSBT_INPUTS: &str = "Too many pending sign PSBT inputs";
 const ERR_INVALID_STORAGE_DEPOSIT: &str = "Invalid storage deposit amount";
 const ERR_INSUFFICIENT_STORAGE_DEPOSIT: &str = "Insufficient storage deposit";
 const ERR_INVALID_PSBT_HEX: &str = "Invalid PSBT hex";
@@ -50,6 +51,7 @@ const ERR_INVALID_TX_HEX: &str = "Invalid txn hex";
 const ERR_NOT_WITHDRAW_TXN: &str = "Not a withdrawal transaction";
 
 const MAX_PENDING_SIGN_PSBT_LEN: u64 = 100;
+const MAX_PENDING_SIGN_PSBT_INPUTS: usize = 100;
 const REFUND_THRESHOLD: Balance = ONE_NEAR / 100; // 0.01 NEAR
 
 /// in case different wallet signs message in different form,
@@ -207,6 +209,10 @@ impl Contract {
             require!(
                 account.pending_sign_psbts.len() < MAX_PENDING_SIGN_PSBT_LEN,
                 ERR_TOO_MANY_PENDING_SIGN_PSBT
+            );
+            require!(
+                psbt.unsigned_tx.input.len() <= MAX_PENDING_SIGN_PSBT_INPUTS,
+                ERR_TOO_MANY_PENDING_SIGN_PSBT_INPUTS
             );
 
             let (actual_withdraw_amount, reinvest_deposit_vout) =

--- a/contracts/bithive/src/withdraw.rs
+++ b/contracts/bithive/src/withdraw.rs
@@ -232,9 +232,9 @@ impl Contract {
             });
             account.pending_sign_psbts_size += psbt_bytes.len();
             account.queue_withdrawal_amount -= actual_withdraw_amount;
-
-            self.set_account(account);
         }
+
+        self.set_account(account);
 
         // request signature from chain signatures
         let payload = get_hash_to_sign(&psbt, vin_to_sign);

--- a/contracts/bithive/src/withdraw.rs
+++ b/contracts/bithive/src/withdraw.rs
@@ -21,7 +21,7 @@ use utils::{
     verify_signed_message_ecdsa,
 };
 
-const GAS_CHAIN_SIG_SIGN: Gas = Gas(250 * Gas::ONE_TERA.0);
+const GAS_CHAIN_SIG_SIGN: Gas = Gas(50 * Gas::ONE_TERA.0);
 const GAS_CHAIN_SIG_SIGN_CB: Gas = Gas(10 * Gas::ONE_TERA.0);
 const GAS_WITHDRAW_VERIFY_CB: Gas = Gas(80 * Gas::ONE_TERA.0);
 const GAS_BIP322_VERIFY: Gas = Gas(20 * Gas::ONE_TERA.0);
@@ -164,7 +164,7 @@ impl Contract {
     ) -> Promise {
         self.assert_running();
 
-        assert_gas(Gas(40 * Gas::ONE_TERA.0) + GAS_CHAIN_SIG_SIGN + GAS_CHAIN_SIG_SIGN_CB); // 300 Tgas
+        assert_gas(Gas(40 * Gas::ONE_TERA.0) + GAS_CHAIN_SIG_SIGN + GAS_CHAIN_SIG_SIGN_CB); // 100 Tgas
 
         let psbt_bytes = hex::decode(psbt_hex).unwrap();
         let psbt = Psbt::deserialize(&psbt_bytes).expect(ERR_INVALID_PSBT_HEX);

--- a/contracts/bithive/src/withdraw.rs
+++ b/contracts/bithive/src/withdraw.rs
@@ -213,10 +213,12 @@ impl Contract {
                     env::attached_deposit() >= attached_near_for_storage,
                     ERR_INVALID_STORAGE_DEPOSIT
                 );
-                // charge at least for the PSBT itself, but the user can attach more for future use
-                let storage_needed = psbt_bytes.len() as u128 * env::storage_byte_cost();
+                let total_storage_needed = (account.pending_sign_psbts_size + psbt_bytes.len())
+                    as u128
+                    * env::storage_byte_cost();
                 require!(
-                    account.pending_sign_deposit + attached_near_for_storage >= storage_needed,
+                    account.pending_sign_deposit + attached_near_for_storage
+                        >= total_storage_needed,
                     ERR_INSUFFICIENT_STORAGE_DEPOSIT
                 );
             }
@@ -227,6 +229,7 @@ impl Contract {
                 reinvest_deposit_vout,
                 reinvest_embed_vout,
             });
+            account.pending_sign_psbts_size += psbt_bytes.len();
             account.queue_withdrawal_amount -= actual_withdraw_amount;
 
             self.set_account(account);

--- a/contracts/bithive/src/withdraw.rs
+++ b/contracts/bithive/src/withdraw.rs
@@ -171,9 +171,15 @@ impl Contract {
         // verify the PSBT is partially signed by the user
         verify_pending_sign_partial_sig(&psbt, vin_to_sign, &user_pubkey);
 
+        // verify enough storage deposit is attached
+        let attached_near_for_storage: Balance = storage_deposit.unwrap_or(U128::from(0)).into();
+        require!(
+            env::attached_deposit() >= attached_near_for_storage,
+            ERR_INVALID_STORAGE_DEPOSIT
+        );
+
         let mut account = self.get_account(&user_pubkey.clone().into());
 
-        let mut attached_near_for_storage = 0u128;
         let input_to_sign = psbt.unsigned_tx.input.get(vin_to_sign as usize).unwrap();
         let deposit = account.get_active_deposit(
             &input_to_sign.previous_output.txid.to_string().into(),
@@ -208,11 +214,6 @@ impl Contract {
 
             // if there are more than one pending sign PSBT or the PSBT has more than one input, we need to charge the user for PSBT storage deposit
             if !account.pending_sign_psbts.is_empty() || psbt.unsigned_tx.input.len() > 1 {
-                attached_near_for_storage = storage_deposit.unwrap_or(U128::from(0)).into();
-                require!(
-                    env::attached_deposit() >= attached_near_for_storage,
-                    ERR_INVALID_STORAGE_DEPOSIT
-                );
                 let total_storage_needed = (account.pending_sign_psbts_size + psbt_bytes.len())
                     as u128
                     * env::storage_byte_cost();

--- a/contracts/bithive/src/withdraw.rs
+++ b/contracts/bithive/src/withdraw.rs
@@ -21,7 +21,7 @@ use utils::{
     verify_signed_message_ecdsa,
 };
 
-const GAS_CHAIN_SIG_SIGN: Gas = Gas(50 * Gas::ONE_TERA.0);
+const GAS_CHAIN_SIG_SIGN: Gas = Gas(20 * Gas::ONE_TERA.0);
 const GAS_CHAIN_SIG_SIGN_CB: Gas = Gas(10 * Gas::ONE_TERA.0);
 const GAS_WITHDRAW_VERIFY_CB: Gas = Gas(80 * Gas::ONE_TERA.0);
 const GAS_BIP322_VERIFY: Gas = Gas(20 * Gas::ONE_TERA.0);
@@ -164,7 +164,7 @@ impl Contract {
     ) -> Promise {
         self.assert_running();
 
-        assert_gas(Gas(40 * Gas::ONE_TERA.0) + GAS_CHAIN_SIG_SIGN + GAS_CHAIN_SIG_SIGN_CB); // 100 Tgas
+        assert_gas(Gas(40 * Gas::ONE_TERA.0) + GAS_CHAIN_SIG_SIGN + GAS_CHAIN_SIG_SIGN_CB); // 70 Tgas
 
         let psbt_bytes = hex::decode(psbt_hex).unwrap();
         let psbt = Psbt::deserialize(&psbt_bytes).expect(ERR_INVALID_PSBT_HEX);

--- a/contracts/bithive/src/withdraw.rs
+++ b/contracts/bithive/src/withdraw.rs
@@ -351,6 +351,12 @@ impl Contract {
         }
         self.set_account(account);
 
+        Event::Withdrawn {
+            user_pubkey: &user_pubkey,
+            withdrawal_tx_id: &tx_id.to_string().into(),
+        }
+        .emit();
+
         true
     }
 }

--- a/contracts/bithive/src/withdraw.rs
+++ b/contracts/bithive/src/withdraw.rs
@@ -23,7 +23,7 @@ use utils::{
 
 const GAS_CHAIN_SIG_SIGN: Gas = Gas(20 * Gas::ONE_TERA.0);
 const GAS_CHAIN_SIG_SIGN_CB: Gas = Gas(10 * Gas::ONE_TERA.0);
-const GAS_WITHDRAW_VERIFY_CB: Gas = Gas(80 * Gas::ONE_TERA.0);
+const GAS_WITHDRAW_VERIFY_CB: Gas = Gas(275 * Gas::ONE_TERA.0);
 const GAS_BIP322_VERIFY: Gas = Gas(20 * Gas::ONE_TERA.0);
 const GAS_BIP322_VERIFY_CB: Gas = Gas(20 * Gas::ONE_TERA.0);
 
@@ -300,7 +300,7 @@ impl Contract {
     pub fn submit_withdrawal_tx(&mut self, args: SubmitWithdrawTxArgs) -> Promise {
         self.assert_running();
 
-        assert_gas(Gas(30 * Gas::ONE_TERA.0) + GAS_LIGHT_CLIENT_VERIFY + GAS_WITHDRAW_VERIFY_CB); // 140 Tgas
+        assert_gas(Gas(20 * Gas::ONE_TERA.0) + GAS_LIGHT_CLIENT_VERIFY + GAS_WITHDRAW_VERIFY_CB); // 300 Tgas
 
         let tx = deserialize_hex::<Transaction>(&args.tx_hex).expect(ERR_INVALID_TX_HEX);
         let txid = tx.compute_txid();
@@ -353,7 +353,7 @@ impl Contract {
 
         Event::Withdrawn {
             user_pubkey: &user_pubkey,
-            withdrawal_tx_id: &tx_id.to_string().into(),
+            withdrawal_tx_id: &tx_id.to_string(),
         }
         .emit();
 

--- a/contracts/bithive/src/withdraw.rs
+++ b/contracts/bithive/src/withdraw.rs
@@ -166,13 +166,14 @@ impl Contract {
 
         assert_gas(Gas(40 * Gas::ONE_TERA.0) + GAS_CHAIN_SIG_SIGN + GAS_CHAIN_SIG_SIGN_CB); // 300 Tgas
 
-        let mut attached_near_for_storage = 0u128;
-
         let psbt_bytes = hex::decode(psbt_hex).unwrap();
         let psbt = Psbt::deserialize(&psbt_bytes).expect(ERR_INVALID_PSBT_HEX);
+        // verify the PSBT is partially signed by the user
+        verify_pending_sign_partial_sig(&psbt, vin_to_sign, &user_pubkey);
 
         let mut account = self.get_account(&user_pubkey.clone().into());
 
+        let mut attached_near_for_storage = 0u128;
         let input_to_sign = psbt.unsigned_tx.input.get(vin_to_sign as usize).unwrap();
         let deposit = account.get_active_deposit(
             &input_to_sign.previous_output.txid.to_string().into(),
@@ -186,14 +187,22 @@ impl Contract {
                 .get(pending_sign_psbt_idx)
                 .expect(ERR_INVALID_PENDING_SIGN_PSBT_IDX);
             verify_sign_withdrawal_psbt(&saved_psbt, &psbt);
+
+            account.pending_sign_psbts.replace(
+                pending_sign_psbt_idx,
+                &PendingSignPsbt {
+                    psbt: psbt.clone().into(),
+                    reinvest_deposit_vout: saved_psbt.reinvest_deposit_vout,
+                    reinvest_embed_vout: saved_psbt.reinvest_embed_vout,
+                },
+            );
         } else {
             // if no pending sign PSBT index is provided, treat the PSBT as a new request, which should decrease the queue withdrawal amount
             require!(
-                account.pending_sign_psbts.len() <= MAX_PENDING_SIGN_PSBT_LEN,
+                account.pending_sign_psbts.len() < MAX_PENDING_SIGN_PSBT_LEN,
                 ERR_TOO_MANY_PENDING_SIGN_PSBT
             );
 
-            verify_pending_sign_partial_sig(&psbt, vin_to_sign, &user_pubkey);
             let (actual_withdraw_amount, reinvest_deposit_vout) =
                 self.verify_pending_sign_request_amount(&account, &psbt, reinvest_embed_vout);
 
@@ -212,6 +221,7 @@ impl Contract {
                 );
             }
 
+            account.pending_sign_deposit += attached_near_for_storage;
             account.pending_sign_psbts.push(&PendingSignPsbt {
                 psbt: psbt.clone().into(),
                 reinvest_deposit_vout,

--- a/contracts/mock-chain-signatures/src/lib.rs
+++ b/contracts/mock-chain-signatures/src/lib.rs
@@ -32,7 +32,7 @@ pub struct SignatureResponse {
     pub recovery_id: u8,
 }
 
-const GAS_FOR_SIGN_CALL: Gas = Gas(250 * Gas::ONE_TERA.0);
+const GAS_FOR_SIGN_CALL: Gas = Gas(10 * Gas::ONE_TERA.0);
 
 #[near_bindgen]
 #[derive(BorshSerialize, BorshDeserialize, Default)]

--- a/tests/__tests__/deposit.ava.ts
+++ b/tests/__tests__/deposit.ava.ts
@@ -48,7 +48,7 @@ test("submit valid deposit txn", async (t) => {
   t.is(account.queue_withdrawal_amount, 0);
   t.is(account.queue_withdrawal_start_ts, 0);
   t.is(account.nonce, 0);
-  t.is(account.pending_sign_psbt, null);
+  t.is(account.pending_sign_psbts_len, 0);
 });
 
 test("submit invalid embed msg", async (t) => {

--- a/tests/__tests__/helpers/bithive.ts
+++ b/tests/__tests__/helpers/bithive.ts
@@ -58,28 +58,36 @@ export async function queueWithdrawal(
   );
 }
 
+interface SignWithdrawalArgs {
+  psbtHex: string;
+  userPubkey: string;
+  vinToSign: number;
+  pendingSignPsbtIdx?: number;
+  reinvestEmbedVout?: number;
+  storageDeposit?: NEAR;
+}
+
 export async function signWithdrawal(
   bithive: NearAccount,
   caller: NearAccount,
-  psbtHex: string,
-  userPubkey: string,
-  vinToSign: number,
-  reinvestEmbedVout?: number,
-  storageDeposit?: NEAR,
+  args: SignWithdrawalArgs,
 ): Promise<ChainSignatureResponse | null> {
   const attachedDeposit = NEAR.parse("0.5").add(
-    storageDeposit ?? NEAR.parse("0"),
+    args.storageDeposit ?? NEAR.parse("0"),
   );
 
   return caller.call(
     bithive.accountId,
     "sign_withdrawal",
     {
-      psbt_hex: psbtHex,
-      user_pubkey: userPubkey,
-      vin_to_sign: vinToSign,
-      reinvest_embed_vout: reinvestEmbedVout,
-      storage_deposit: storageDeposit ? storageDeposit.toString() : null,
+      psbt_hex: args.psbtHex,
+      user_pubkey: args.userPubkey,
+      vin_to_sign: args.vinToSign,
+      pending_sign_psbt_idx: args.pendingSignPsbtIdx,
+      reinvest_embed_vout: args.reinvestEmbedVout,
+      storage_deposit: args.storageDeposit
+        ? args.storageDeposit.toString()
+        : null,
     },
     {
       attachedDeposit,
@@ -309,10 +317,7 @@ interface Account {
   queue_withdrawal_amount: number;
   queue_withdrawal_start_ts: number;
   nonce: number;
-  pending_sign_psbt: {
-    psbt: string;
-    reinvest_deposit_vout: number | null;
-  } | null;
+  pending_sign_psbts_len: number;
 }
 
 export async function viewAccount(
@@ -332,4 +337,22 @@ export async function listAccounts(
   limit: number,
 ): Promise<Account[]> {
   return bithive.view("list_accounts", { offset, limit });
+}
+
+interface PendingSignPsbt {
+  psbt: string;
+  reinvest_deposit_vout: number | null;
+}
+
+export async function listPendingSignPsbts(
+  bithive: NearAccount,
+  userPubkey: string,
+  offset: number,
+  limit: number,
+): Promise<PendingSignPsbt[]> {
+  return bithive.view("list_pending_sign_psbts", {
+    user_pubkey: userPubkey,
+    offset,
+    limit,
+  });
 }

--- a/tests/__tests__/helpers/bithive.ts
+++ b/tests/__tests__/helpers/bithive.ts
@@ -114,7 +114,7 @@ export async function submitWithdrawalTx(
       args,
     },
     {
-      gas: Gas.parse("200 Tgas"),
+      gas: Gas.parse("300 Tgas"),
     },
   );
 }

--- a/tests/__tests__/helpers/txn_builder.ts
+++ b/tests/__tests__/helpers/txn_builder.ts
@@ -208,14 +208,18 @@ export class TestTransactionBuilder {
     return (this.psbt as any).__CACHE.__TX;
   }
 
-  signWithdraw(vinToSign: number, pendingSignPsbtIdx?: number) {
+  signWithdraw(
+    vinToSign: number,
+    pendingSignPsbtIdx?: number,
+    attachStorageDeposit = false,
+  ) {
     if (!this.psbt) {
       throw new Error("Generate PSBT first");
     }
 
     // attach deposit for multiple inputs
     let storageDeposit: NEAR | undefined = undefined;
-    if (this.psbt.inputCount > 1) {
+    if (attachStorageDeposit) {
       const psbtSize = this.psbt.toHex().length / 2;
       storageDeposit = getStorageDeposit(psbtSize);
     }

--- a/tests/__tests__/helpers/txn_builder.ts
+++ b/tests/__tests__/helpers/txn_builder.ts
@@ -208,7 +208,7 @@ export class TestTransactionBuilder {
     return (this.psbt as any).__CACHE.__TX;
   }
 
-  signWithdraw(vinToSign: number) {
+  signWithdraw(vinToSign: number, pendingSignPsbtIdx?: number) {
     if (!this.psbt) {
       throw new Error("Generate PSBT first");
     }
@@ -220,15 +220,14 @@ export class TestTransactionBuilder {
       storageDeposit = getStorageDeposit(psbtSize);
     }
 
-    return signWithdrawal(
-      this.bithive,
-      this.caller,
-      this.psbt.toHex(),
-      this.userPubkey.toString("hex"),
+    return signWithdrawal(this.bithive, this.caller, {
+      psbtHex: this.psbt.toHex(),
+      userPubkey: this.userPubkey.toString("hex"),
       vinToSign,
-      this.reinvest ? 2 : undefined, // if reinvest, the embed ouput will be index 2
+      pendingSignPsbtIdx,
+      reinvestEmbedVout: this.reinvest ? 2 : undefined,
       storageDeposit,
-    );
+    });
   }
 
   submitWithdraw() {

--- a/tests/__tests__/integration/e2e_workflow.ava.ts
+++ b/tests/__tests__/integration/e2e_workflow.ava.ts
@@ -148,21 +148,26 @@ test("Deposit and withdraw workflow e2e", async (t) => {
     contract,
     alice,
     mockChainSignature,
-    partialSignedPsbt1,
-    0,
-    1,
-    aliceKp.publicKey.toString("hex"),
-    hashToSign1,
+    {
+      psbt: partialSignedPsbt1,
+      depositVin: 0,
+      reinvestVout: 1,
+      userPubkey: aliceKp.publicKey.toString("hex"),
+      hashToSign: hashToSign1,
+    },
   );
   const bithiveSig2 = await makeSignWithdrawal(
     contract,
     alice,
     mockChainSignature,
-    partialSignedPsbt2,
-    1,
-    1,
-    aliceKp.publicKey.toString("hex"),
-    hashToSign2,
+    {
+      psbt: partialSignedPsbt2,
+      pendingSignPsbtIdx: 0,
+      depositVin: 1,
+      reinvestVout: 1,
+      userPubkey: aliceKp.publicKey.toString("hex"),
+      hashToSign: hashToSign2,
+    },
   );
 
   // construct txn to broadcast
@@ -423,32 +428,34 @@ async function makeSignWithdrawal(
   contract: NearAccount,
   caller: NearAccount,
   mockChainSignature: NearAccount,
-  psbt: bitcoin.Psbt,
-  depositVin: number,
-  reinvestVout: number,
-  userPubkey: string,
-  hashToSign: Buffer,
+  args: {
+    psbt: bitcoin.Psbt;
+    depositVin: number;
+    reinvestVout: number;
+    userPubkey: string;
+    hashToSign: Buffer;
+    pendingSignPsbtIdx?: number;
+  },
 ) {
   // fetch real signature from testnet and upload to mock chain sig contract
-  await prepareBitHiveSignature(mockChainSignature, hashToSign);
+  await prepareBitHiveSignature(mockChainSignature, args.hashToSign);
 
   // attach storage deposit for multiple inputs
   let storageDeposit: NEAR | undefined = undefined;
-  if (psbt.inputCount > 1) {
-    const psbtSize = psbt.toHex().length / 2;
+  if (args.psbt.inputCount > 1) {
+    const psbtSize = args.psbt.toHex().length / 2;
     storageDeposit = getStorageDeposit(psbtSize);
   }
 
   // call BitHive contract to sign withdrawal PSBT
-  const sig = await signWithdrawal(
-    contract,
-    caller,
-    psbt.toHex(),
-    userPubkey,
-    depositVin,
-    reinvestVout,
+  const sig = await signWithdrawal(contract, caller, {
+    psbtHex: args.psbt.toHex(),
+    userPubkey: args.userPubkey,
+    vinToSign: args.depositVin,
+    pendingSignPsbtIdx: args.pendingSignPsbtIdx,
+    reinvestEmbedVout: args.reinvestVout,
     storageDeposit,
-  );
+  });
 
   return bitcoin.script.signature.encode(
     reconstructSignature(sig!.big_r.affine_point, sig!.s.scalar),

--- a/tests/__tests__/queue_withdrawal.ava.ts
+++ b/tests/__tests__/queue_withdrawal.ava.ts
@@ -54,7 +54,7 @@ test("valid queue withdrawal", async (t) => {
   t.is(account.queue_withdrawal_amount, 100);
   t.is(account.queue_withdrawal_start_ts, daysToMs(3));
   t.is(account.nonce, 1);
-  t.is(account.pending_sign_psbt, null);
+  t.is(account.pending_sign_psbts_len, 0);
 });
 
 test("queue withdrawal with wrong amount in signature", async (t) => {
@@ -137,15 +137,13 @@ test("queue withdrawal should clear pending withdrawal psbt", async (t) => {
   await builder.signWithdraw(0);
 
   let account = await viewAccount(contract, builder.userPubkeyHex);
-  t.assert(account.pending_sign_psbt);
-  t.assert(account.pending_sign_psbt!.psbt);
-  t.assert(account.pending_sign_psbt!.reinvest_deposit_vout);
+  t.assert(account.pending_sign_psbts_len === 1);
 
   const sig2 = builder.queueWithdrawSignature(100, 1);
   await builder.queueWithdraw(100, sig2);
 
   account = await viewAccount(contract, builder.userPubkeyHex);
-  t.assert(account.pending_sign_psbt === null);
+  t.assert(account.pending_sign_psbts_len === 0);
 });
 
 test("queue withdrawal with bip322 signature", async (t) => {

--- a/tests/__tests__/sign_withdrawal.ava.ts
+++ b/tests/__tests__/sign_withdrawal.ava.ts
@@ -210,7 +210,8 @@ test("sign withdrawal twice but with different PSBT", async (t) => {
     undefined,
     depositAmount1 - actualWithdrawAmount1,
   );
-  await builder1.signWithdraw(0);
+  // attach storage deposit since we will sign with multiple inputs
+  await builder1.signWithdraw(0, undefined, true);
 
   const actualWithdrawAmount2 = 1e3;
   builder2.generateWithdrawPsbt(

--- a/tests/__tests__/sign_withdrawal.ava.ts
+++ b/tests/__tests__/sign_withdrawal.ava.ts
@@ -1,5 +1,10 @@
 import * as bitcoin from "bitcoinjs-lib";
-import { fastForward, signWithdrawal, viewAccount } from "./helpers/bithive";
+import {
+  fastForward,
+  listPendingSignPsbts,
+  signWithdrawal,
+  viewAccount,
+} from "./helpers/bithive";
 import { initUnit } from "./helpers/context";
 import { TestTransactionBuilder } from "./helpers/txn_builder";
 import { assertFailure, buildDepositEmbedMsg, daysToMs } from "./helpers/utils";
@@ -42,13 +47,11 @@ test("sign withdrawal with invalid PSBT", async (t) => {
 
   await assertFailure(
     t,
-    signWithdrawal(
-      contract,
-      alice,
-      `11${psbtHex}`, // wrong
-      userPubkey.toString("hex"),
-      1,
-    ),
+    signWithdrawal(contract, alice, {
+      psbtHex: `11${psbtHex}`,
+      userPubkey: userPubkey.toString("hex"),
+      vinToSign: 1,
+    }),
     "Invalid PSBT hex",
   );
 });
@@ -92,11 +95,19 @@ test("sign withdrawal should set pending withdrawal psbt", async (t) => {
   await builder.signWithdraw(0);
 
   const account = await viewAccount(contract, builder.userPubkeyHex);
-  t.is(account.pending_sign_psbt!.psbt, builder.psbt!.toHex());
-  t.is(account.pending_sign_psbt!.reinvest_deposit_vout, 1);
+  t.is(account.pending_sign_psbts_len, 1);
+  const pendingSignPsbts = await listPendingSignPsbts(
+    contract,
+    builder.userPubkeyHex,
+    0,
+    1,
+  );
+  t.is(pendingSignPsbts[0].psbt, builder.psbt!.toHex());
+  t.is(pendingSignPsbts[0].reinvest_deposit_vout, 1);
 });
 
-test("sign withdrawal should reset queue withdrawal amount", async (t) => {
+// TODO
+test.skip("sign withdrawal should decrease queue withdrawal amount", async (t) => {
   const { builder, contract } = await makeDeposit(t, 1e8);
 
   const sig = builder.queueWithdrawSignature(100, 0);
@@ -106,9 +117,7 @@ test("sign withdrawal should reset queue withdrawal amount", async (t) => {
   builder.generateWithdrawPsbt(undefined, 1e8 - 100);
   await builder.signWithdraw(0);
 
-  const account = await viewAccount(contract, builder.userPubkeyHex);
-  t.is(account.queue_withdrawal_amount, 0);
-  t.is(account.queue_withdrawal_start_ts, 0);
+  // const account = await viewAccount(contract, builder.userPubkeyHex);
 });
 
 test("sign withdrawal with multiple deposit inputs", async (t) => {
@@ -130,7 +139,7 @@ test("sign withdrawal with multiple deposit inputs", async (t) => {
   );
 
   await builder1.signWithdraw(0);
-  await builder1.signWithdraw(1);
+  await builder1.signWithdraw(1, 0);
 });
 
 test("sign withdrawal without storage deposit for multiple deposit inputs should fail", async (t) => {
@@ -153,13 +162,11 @@ test("sign withdrawal without storage deposit for multiple deposit inputs should
 
   await assertFailure(
     t,
-    signWithdrawal(
-      builder1.bithive,
-      builder1.caller,
-      builder1.psbt!.toHex(),
-      builder1.userPubkeyHex,
-      0,
-    ),
+    signWithdrawal(builder1.bithive, builder1.caller, {
+      psbtHex: builder1.psbt!.toHex(),
+      userPubkey: builder1.userPubkeyHex,
+      vinToSign: 0,
+    }),
     "Insufficient storage deposit",
   );
 });
@@ -179,10 +186,11 @@ test("sign withdrawal RBF", async (t) => {
   withdrawAmount -= 90;
   builder.generateWithdrawPsbt(undefined, 1e8 - 100, withdrawAmount); // actual withdrawal amount is only 10 sats
   // sign the new psbt
-  await builder.signWithdraw(0);
+  await builder.signWithdraw(0, 0);
 });
 
-test("sign withdrawal twice but with different PSBT", async (t) => {
+// TODO: allow if within limit
+test.skip("sign withdrawal twice but with different PSBT", async (t) => {
   const { builder: builder1, contract } = await makeDeposit(t, 1e8);
   const { builder: builder2 } = await makeDeposit(t, 100);
 
@@ -248,14 +256,12 @@ test("sign withdrawal with invalid reinvestment type", async (t) => {
 
   await assertFailure(
     t,
-    signWithdrawal(
-      contract,
-      account,
-      partialSignedPsbt.toHex(),
-      userPubkey.toString("hex"),
-      0,
-      2,
-    ),
+    signWithdrawal(contract, account, {
+      psbtHex: partialSignedPsbt.toHex(),
+      userPubkey: userPubkey.toString("hex"),
+      vinToSign: 0,
+      reinvestEmbedVout: 2,
+    }),
     "Deposit output is not P2WSH",
   );
 });

--- a/tests/__tests__/sign_withdrawal.ava.ts
+++ b/tests/__tests__/sign_withdrawal.ava.ts
@@ -71,6 +71,7 @@ test("sign withdrawal with invalid deposit vin", async (t) => {
     hash: "0000000000000000000000000000000000000000000000000000000000000000",
     index: 1,
   });
+  builder.partialSignWithdrawPsbt(1);
 
   await assertFailure(t, builder.signWithdraw(1), "Deposit is not active");
 });
@@ -106,18 +107,20 @@ test("sign withdrawal should set pending withdrawal psbt", async (t) => {
   t.is(pendingSignPsbts[0].reinvest_deposit_vout, 1);
 });
 
-// TODO
-test.skip("sign withdrawal should decrease queue withdrawal amount", async (t) => {
-  const { builder, contract } = await makeDeposit(t, 1e8);
+test("sign withdrawal should decrease queue withdrawal amount", async (t) => {
+  const depositAmount = 1e8;
+  const withdrawAmount = 1e4;
+  const { builder, contract } = await makeDeposit(t, depositAmount);
 
-  const sig = builder.queueWithdrawSignature(100, 0);
-  await builder.queueWithdraw(100, sig);
+  const sig = builder.queueWithdrawSignature(depositAmount, 0);
+  await builder.queueWithdraw(depositAmount, sig);
   await fastForward(contract, daysToMs(2));
 
-  builder.generateWithdrawPsbt(undefined, 1e8 - 100);
+  builder.generateWithdrawPsbt(undefined, depositAmount - withdrawAmount);
   await builder.signWithdraw(0);
 
-  // const account = await viewAccount(contract, builder.userPubkeyHex);
+  const account = await viewAccount(contract, builder.userPubkeyHex);
+  t.is(account.queue_withdrawal_amount, depositAmount - withdrawAmount);
 });
 
 test("sign withdrawal with multiple deposit inputs", async (t) => {
@@ -138,7 +141,9 @@ test("sign withdrawal with multiple deposit inputs", async (t) => {
     3e8,
   );
 
-  await builder1.signWithdraw(0);
+  await builder1.signWithdraw(0, undefined, true);
+
+  builder1.partialSignWithdrawPsbt(1);
   await builder1.signWithdraw(1, 0);
 });
 
@@ -189,30 +194,37 @@ test("sign withdrawal RBF", async (t) => {
   await builder.signWithdraw(0, 0);
 });
 
-// TODO: allow if within limit
-test.skip("sign withdrawal twice but with different PSBT", async (t) => {
-  const { builder: builder1, contract } = await makeDeposit(t, 1e8);
-  const { builder: builder2 } = await makeDeposit(t, 100);
+test("sign withdrawal twice but with different PSBT", async (t) => {
+  const depositAmount1 = 1e8;
+  const depositAmount2 = 1e3;
+  const { builder: builder1, contract } = await makeDeposit(t, depositAmount1);
+  const { builder: builder2 } = await makeDeposit(t, depositAmount2);
 
-  const sig = builder1.queueWithdrawSignature(100, 0);
-  await builder1.queueWithdraw(100, sig);
+  const queueWithdrawAmount = depositAmount1 + depositAmount2;
+  const sig = builder1.queueWithdrawSignature(queueWithdrawAmount, 0);
+  await builder1.queueWithdraw(queueWithdrawAmount, sig);
   await fastForward(contract, daysToMs(2));
 
+  const actualWithdrawAmount1 = 1e5;
   builder1.generateWithdrawPsbt(
-    {
-      hash: builder2.tx.getId(),
-      index: 0,
-    },
-    1e8,
+    undefined,
+    depositAmount1 - actualWithdrawAmount1,
   );
   await builder1.signWithdraw(0);
 
-  builder2.generateWithdrawPsbt();
-  await assertFailure(
-    t,
-    builder2.signWithdraw(0),
-    "PSBT input length mismatch",
+  const actualWithdrawAmount2 = 1e3;
+  builder2.generateWithdrawPsbt(
+    undefined,
+    depositAmount2 - actualWithdrawAmount2,
   );
+  await builder2.signWithdraw(0, undefined, true);
+
+  const account = await viewAccount(contract, builder1.userPubkeyHex);
+  t.is(
+    account.queue_withdrawal_amount,
+    queueWithdrawAmount - actualWithdrawAmount1 - actualWithdrawAmount2,
+  );
+  t.is(account.pending_sign_psbts_len, 2);
 });
 
 test("sign withdrawal without reinvestment", async (t) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for managing multiple pending withdrawal requests (PSBTs) per account, including listing and paginating pending PSBTs.
  - Introduced limits on the number of pending withdrawal requests per account.
  - Added a migration method for upgrading legacy accounts to the new multi-PSBT format.

- **Enhancements**
  - Updated withdrawal signing and verification to specify which pending PSBT to act upon.
  - Improved account views to display the count and size of pending withdrawal requests.
  - Refactored withdrawal signing interface to use structured argument objects for clarity and extensibility.
  - Reduced gas requirements for signing operations and light client verification to improve efficiency.
  - Enhanced external contract interaction by allowing domain-specific public key queries.
  - Updated event data to simplify withdrawal event information.

- **Bug Fixes**
  - Adjusted error handling for invalid or excessive pending withdrawal requests.

- **Tests**
  - Updated and refactored test cases to validate multi-PSBT handling and new API interfaces.
  - Modified assertions and test helpers to reflect changes from single to multiple pending PSBTs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->